### PR TITLE
test: remove chromium test

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -35,10 +35,10 @@ export default defineConfig<TestOptions>({
 
   /* Configure projects for major browsers */
   projects: [
-    {
-      name: 'chromium',
-      use: { ...devices['Desktop Chrome'], email: 'chrome@example.it' },
-    },
+    // {
+    //   name: 'chromium',
+    //   use: { ...devices['Desktop Chrome'], email: 'chrome@example.it' },
+    // },
 
     {
       name: 'firefox',


### PR DESCRIPTION
This pull request includes changes to the `playwright.config.ts` file. The most important change is the commented-out configuration for the Chromium browser project. This is due to a problem currently only shown inside the github actions runners, in which only firefox and webkit tests are working.

When the issue is resolved the test will be brought back.